### PR TITLE
Simple implementation of SmartVector.

### DIFF
--- a/2017/2017-03-08/smartvector/smartvector.go
+++ b/2017/2017-03-08/smartvector/smartvector.go
@@ -1,9 +1,17 @@
 package smartvector
 
+
+type Node struct {
+     posMap int
+     value int
+     next *Node
+}
+
 type SmartVector struct {
-	posBitMap uint64
+	posBitMap int
 	value     int
 	next      *SmartVector
+        head      *Node
 }
 
 var _ Vector = (*SmartVector)(nil)
@@ -13,32 +21,38 @@ func (v *SmartVector) New(n int) Vector {
 }
 
 func (v *SmartVector) Set(i, value int) {
-	if v.posBitMap == 0 {
-		v.value = value
-		v.posBitMap = setNthBit(v.posBitMap, i)
-		// v.posBitMap |= uint64(i + 1)
-		return
-	}
+        if v.head == nil {
+           v.head = &Node{i, value, nil}
+        } else {
+           present := false
+           currNode := v.head
+           for ; currNode.next != nil; {
+               if currNode.value == value {
+                  present = true
+                  currNode.posMap = currNode.posMap | i
+                  break
+               }
+               currNode = currNode.next
+           } 
+           if !present {
+           newNode := Node{i, value, nil}
+           currNode.next = &newNode           
+           }
+        }
 
-	curr := v
-	for ; curr.next != nil; curr = curr.next {
-	}
-
-	curr.next = &SmartVector{value: value}
 }
 
 func (v *SmartVector) Get(i int) int {
-	for curr := v; !(curr.posBitMap & uint64(i+1)); curr = curr.next {
-
-	}
-
-	if i == 1 {
-		return v.next.value
-	}
-	if i == 2 {
-		return v.next.next.value
-	}
-	return v.value
+        resultNode := -1       
+        for currNode := v.head ; currNode != nil; {
+            found := (currNode.posMap & i) == i
+            if found {              
+               resultNode = currNode.value
+               break
+            }
+            currNode = currNode.next                   
+        }
+        return resultNode 
 }
 
 func setNthBit(toModify uint64, n int) uint64 {

--- a/2017/2017-03-08/smartvector/smartvector.go
+++ b/2017/2017-03-08/smartvector/smartvector.go
@@ -2,7 +2,7 @@ package smartvector
 
 
 type Node struct {
-     posMap int
+     posMap uint64
      value int
      next *Node
 }
@@ -21,22 +21,22 @@ func (v *SmartVector) New(n int) Vector {
 }
 
 func (v *SmartVector) Set(i, value int) {
+        var posMap uint64
         if v.head == nil {
-           v.head = &Node{i, value, nil}
+           v.head = &Node{setBitAtPosition(posMap, uint64(i)), value, nil}
         } else {
            present := false
            currNode := v.head
            for ; currNode.next != nil; {
                if currNode.value == value {
                   present = true
-                  currNode.posMap = currNode.posMap | i
+                  currNode.posMap = setBitAtPosition(currNode.posMap, uint64(i))
                   break
                }
                currNode = currNode.next
            } 
            if !present {
-           newNode := Node{i, value, nil}
-           currNode.next = &newNode           
+           currNode.next = &Node{setBitAtPosition(posMap, uint64(i)), value, nil}           
            }
         }
 
@@ -45,7 +45,7 @@ func (v *SmartVector) Set(i, value int) {
 func (v *SmartVector) Get(i int) int {
         resultNode := -1       
         for currNode := v.head ; currNode != nil; {
-            found := (currNode.posMap & i) == i
+            found := checkIfSet(currNode.posMap, uint64(i))
             if found {              
                resultNode = currNode.value
                break
@@ -55,7 +55,11 @@ func (v *SmartVector) Get(i int) int {
         return resultNode 
 }
 
-func setNthBit(toModify uint64, n int) uint64 {
-	// toBitwiseOr :
-	return toModify + 1
+func checkIfSet(bitMap, bitPosition uint64) bool {
+   return (bitMap & (1 << bitPosition)) == (1 << bitPosition)
+}
+
+func setBitAtPosition(bitMap, bitPosition uint64) uint64 {
+   bitMap |= (1 << bitPosition)
+   return bitMap
 }

--- a/2017/2017-03-08/smartvector/smartvector_test.go
+++ b/2017/2017-03-08/smartvector/smartvector_test.go
@@ -5,22 +5,17 @@ import "testing"
 func TestStoreValueAtPositionAndGetItBack(t *testing.T) {
 	v := (*SmartVector).New(nil, 1)
 	v.Set(0, 10)
-	got := v.Get(0)
-	if got != 10 {
-		t.Errorf("Faiiiiiil!!!!")
-	}
+        assertEquals(t, 0, 10, v.Get(0))
 }
 
 func TestStoreEqualAdjacentValues(t *testing.T) {
 	v := (*SmartVector).New(nil, 2)
 	v.Set(0, 10)
 	v.Set(1, 10)
-	if got := v.Get(0); got != 10 {
-		t.Errorf("v.Get(%v) == %v, want %v", 0, got, 10)
-	}
-	if got := v.Get(1); got != 10 {
-		t.Errorf("v.Get(%v) == %v, want %v", 1, got, 10)
-	}
+
+        assertEquals(t, 0, 10, v.Get(0))
+        assertEquals(t, 1, 10, v.Get(1))
+
 }
 
 func TestStoreDifferentAdjacentValues(t *testing.T) {
@@ -28,14 +23,27 @@ func TestStoreDifferentAdjacentValues(t *testing.T) {
 	v.Set(0, 10)
 	v.Set(1, 11)
 	v.Set(2, 12)
-	if got := v.Get(0); got != 10 {
-		t.Errorf("v.Get(%v) == %v, want %v", 0, got, 10)
-	}
-	if got := v.Get(1); got != 11 {
-		t.Errorf("v.Get(%v) == %v, want %v", 1, got, 11)
-	}
-	if got := v.Get(2); got != 12 {
-		t.Errorf("v.Get(%v) == %v, want %v", 2, got, 12)
-	}
+       
+        assertEquals(t, 0, 10, v.Get(0))
+        assertEquals(t, 1, 11, v.Get(1))
+        assertEquals(t, 2, 12, v.Get(2))
+}
 
+func TestStoreBothDifferentAndEqualAdjacentValues(t *testing.T) {
+	v := (*SmartVector).New(nil, 4)
+	v.Set(0, 10)
+	v.Set(1, 11)
+	v.Set(2, 12)
+        v.Set(5, 10)
+       
+        assertEquals(t, 0, 10, v.Get(0))
+        assertEquals(t, 1, 11, v.Get(1))
+        assertEquals(t, 2, 12, v.Get(2))
+        assertEquals(t, 5, 10, v.Get(5))
+}
+
+func assertEquals(t *testing.T, pos, expected, actual int) {
+    if expected != actual {
+        t.Errorf("Getting element at position [%v] from vector, expected value [%v], but got [%v]", pos, expected, actual)
+    }
 }


### PR DESCRIPTION
Hello everyone,
it is late evening and I have just implemented simple Smartvector. 

It uses linked list under the hood. Implementation passes tests we developed on last Wednesday, but it fails a new test I added today. It  turns out that storing indexes into bitmap is somehow flawed. It can return wrong value for requested index depending on how we grow linked list, this is demonstrated in fourth test case called ```TestStoreBothDifferentAndEqualAdjacentValues```. 

This test case adds 4 values to SmartVector:
```v := (*SmartVector).New(nil, 4)
v.Set(0, 10)
v.Set(1, 11)
v.Set(2, 12)
v.Set(5, 10)
```
which result in linked list with following structure

```[101:10]->[001:11]->[010:12]```

then we query for value at index 1 (binary ```001```) we get value 10 from the vector which is wrong as we should get value 11.

As I said results depend on how we grow underlying linked list.